### PR TITLE
Missing #include

### DIFF
--- a/soundlib/Snd_fx.cpp
+++ b/soundlib/Snd_fx.cpp
@@ -25,6 +25,7 @@
 #include "modsmp_ctrl.h"	// For updating the loop wraparound data with the invert loop effect
 #include "plugins/PlugInterface.h"
 #include "OPL.h"
+#include "MIDIEvents.h"
 
 OPENMPT_NAMESPACE_BEGIN
 


### PR DESCRIPTION
When compiling with NO_PLUGINS I get:
openmpt\soundlib\Snd_fx.cpp(5042): error C2653: 'MIDIEvents': is not a class or namespace name

Maybe lines around 5042 should have ifndef NO_PLUGINS instead