### PR TITLE
Add merge, split and shift rows pattern operations

### DIFF
--- a/mptrack/CommandSet.cpp
+++ b/mptrack/CommandSet.cpp
@@ -555,6 +555,7 @@ void CCommandSet::SetupCommands()
 	DefineKeyCommand(kcOrderlistEditPattern, 1804, _T("Edit Pattern"));
 	DefineKeyCommand(kcOrderlistSwitchToPatternView, 1805, _T("Switch to pattern editor"));
 	DefineKeyCommand(kcDuplicatePattern, 1806, _T("Duplicate Pattern"));
+	DefineKeyCommand(kcMergePattern, 1988, _T("Merge Pattern"));
 	DefineKeyCommand(kcOrderlistPat0, 1807, _T("Pattern index digit 0"));
 	DefineKeyCommand(kcOrderlistPat1, 1808, _T("Pattern index digit 1"));
 	DefineKeyCommand(kcOrderlistPat2, 1809, _T("Pattern index digit 2"));

--- a/mptrack/CommandSet.cpp
+++ b/mptrack/CommandSet.cpp
@@ -555,7 +555,8 @@ void CCommandSet::SetupCommands()
 	DefineKeyCommand(kcOrderlistEditPattern, 1804, _T("Edit Pattern"));
 	DefineKeyCommand(kcOrderlistSwitchToPatternView, 1805, _T("Switch to pattern editor"));
 	DefineKeyCommand(kcDuplicatePattern, 1806, _T("Duplicate Pattern"));
-	DefineKeyCommand(kcMergePattern, 1988, _T("Merge Pattern"));
+	DefineKeyCommand(kcMergePattern, 2011, _T("Merge Pattern"));
+	DefineKeyCommand(kcSplitPattern, 2012, _T("Split Pattern"));
 	DefineKeyCommand(kcOrderlistPat0, 1807, _T("Pattern index digit 0"));
 	DefineKeyCommand(kcOrderlistPat1, 1808, _T("Pattern index digit 1"));
 	DefineKeyCommand(kcOrderlistPat2, 1809, _T("Pattern index digit 2"));

--- a/mptrack/CommandSet.cpp
+++ b/mptrack/CommandSet.cpp
@@ -557,6 +557,7 @@ void CCommandSet::SetupCommands()
 	DefineKeyCommand(kcDuplicatePattern, 1806, _T("Duplicate Pattern"));
 	DefineKeyCommand(kcMergePattern, 2011, _T("Merge Pattern"));
 	DefineKeyCommand(kcSplitPattern, 2012, _T("Split Pattern"));
+	DefineKeyCommand(kcShiftPatternRows, 2013, _T("Shift Pattern Rows"));
 	DefineKeyCommand(kcOrderlistPat0, 1807, _T("Pattern index digit 0"));
 	DefineKeyCommand(kcOrderlistPat1, 1808, _T("Pattern index digit 1"));
 	DefineKeyCommand(kcOrderlistPat2, 1809, _T("Pattern index digit 2"));

--- a/mptrack/CommandSet.h
+++ b/mptrack/CommandSet.h
@@ -266,6 +266,7 @@ enum CommandID
 	kcDuplicatePattern,
 	kcMergePattern,
 	kcSplitPattern,
+	kcShiftPatternRows,
 	kcPatternEditPCNotePlugin,
 	kcTogglePluginEditor,
 	kcShowNoteProperties,

--- a/mptrack/CommandSet.h
+++ b/mptrack/CommandSet.h
@@ -265,6 +265,7 @@ enum CommandID
 	kcNewPattern,
 	kcDuplicatePattern,
 	kcMergePattern,
+	kcSplitPattern,
 	kcPatternEditPCNotePlugin,
 	kcTogglePluginEditor,
 	kcShowNoteProperties,

--- a/mptrack/CommandSet.h
+++ b/mptrack/CommandSet.h
@@ -264,6 +264,7 @@ enum CommandID
 	kcSwitchToOrderList,
 	kcNewPattern,
 	kcDuplicatePattern,
+	kcMergePattern,
 	kcPatternEditPCNotePlugin,
 	kcTogglePluginEditor,
 	kcShowNoteProperties,

--- a/mptrack/Ctrl_pat.h
+++ b/mptrack/Ctrl_pat.h
@@ -162,6 +162,7 @@ protected:
 	afx_msg void OnDuplicatePattern();
 	afx_msg void OnMergePatterns();
 	afx_msg void OnSplitPattern();
+	afx_msg void OnShiftPatternRows();
 	afx_msg void OnPatternCopy();
 	afx_msg void OnPatternPaste();
 	afx_msg void OnSetRestartPos();
@@ -243,6 +244,7 @@ protected:
 	afx_msg void OnPatternDuplicate();
 	afx_msg void OnPatternMerge();
 	afx_msg void OnPatternSplit();
+	afx_msg void OnPatternShiftRows();
 	afx_msg void OnPatternStop();
 	afx_msg void OnPatternPlay();
 	afx_msg void OnPatternPlayNoLoop();		//rewbs.playSongFromCursor

--- a/mptrack/Ctrl_pat.h
+++ b/mptrack/Ctrl_pat.h
@@ -161,6 +161,7 @@ protected:
 	afx_msg void OnCreateNewPattern();
 	afx_msg void OnDuplicatePattern();
 	afx_msg void OnMergePatterns();
+	afx_msg void OnSplitPattern();
 	afx_msg void OnPatternCopy();
 	afx_msg void OnPatternPaste();
 	afx_msg void OnSetRestartPos();
@@ -241,6 +242,7 @@ protected:
 	afx_msg void OnPatternNew();
 	afx_msg void OnPatternDuplicate();
 	afx_msg void OnPatternMerge();
+	afx_msg void OnPatternSplit();
 	afx_msg void OnPatternStop();
 	afx_msg void OnPatternPlay();
 	afx_msg void OnPatternPlayNoLoop();		//rewbs.playSongFromCursor

--- a/mptrack/Ctrl_pat.h
+++ b/mptrack/Ctrl_pat.h
@@ -160,6 +160,7 @@ protected:
 	afx_msg void OnPatternPlayFromStart();
 	afx_msg void OnCreateNewPattern();
 	afx_msg void OnDuplicatePattern();
+	afx_msg void OnMergePatterns();
 	afx_msg void OnPatternCopy();
 	afx_msg void OnPatternPaste();
 	afx_msg void OnSetRestartPos();
@@ -239,6 +240,7 @@ protected:
 	afx_msg void OnPlayerPause();
 	afx_msg void OnPatternNew();
 	afx_msg void OnPatternDuplicate();
+	afx_msg void OnPatternMerge();
 	afx_msg void OnPatternStop();
 	afx_msg void OnPatternPlay();
 	afx_msg void OnPatternPlayNoLoop();		//rewbs.playSongFromCursor

--- a/mptrack/Ctrl_seq.cpp
+++ b/mptrack/Ctrl_seq.cpp
@@ -90,6 +90,7 @@ BEGIN_MESSAGE_MAP(COrderList, CWnd)
 	//ON_COMMAND(ID_PATTERN_RESTART,			&COrderList::OnPatternPlayFromStart)
 	ON_COMMAND(ID_ORDERLIST_NEW,				&COrderList::OnCreateNewPattern)
 	ON_COMMAND(ID_ORDERLIST_COPY,				&COrderList::OnDuplicatePattern)
+    ON_COMMAND(ID_ORDERLIST_MERGE,				&COrderList::OnMergePatterns)
 	ON_COMMAND(ID_PATTERNCOPY,					&COrderList::OnPatternCopy)
 	ON_COMMAND(ID_PATTERNPASTE,					&COrderList::OnPatternPaste)
 	ON_COMMAND(ID_SETRESTARTPOS,				&COrderList::OnSetRestartPos)
@@ -557,6 +558,8 @@ LRESULT COrderList::OnCustomKeyMsg(WPARAM wParam, LPARAM)
 
 	case kcDuplicatePattern:
 		OnDuplicatePattern(); return wParam;
+	case kcMergePattern:
+		OnMergePatterns(); return wParam;
 	case kcNewPattern:
 		OnCreateNewPattern(); return wParam;
 	}
@@ -1043,6 +1046,7 @@ void COrderList::OnRButtonDown(UINT nFlags, CPoint pt)
 		AppendMenu(hMenu, MF_STRING | greyed, ID_PATTERNPASTE, ih->GetKeyTextFromCommand(kcEditPaste, _T("P&aste Patterns")));
 		AppendMenu(hMenu, MF_SEPARATOR, NULL, _T(""));
 		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_COPY, ih->GetKeyTextFromCommand(kcDuplicatePattern, _T("&Duplicate Patterns")));
+		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_MERGE, ih->GetKeyTextFromCommand(kcMergePattern, _T("&Merge Patterns")));
 	} else
 	{
 		// Only one pattern is selected
@@ -1301,6 +1305,12 @@ void COrderList::OnCreateNewPattern()
 void COrderList::OnDuplicatePattern()
 {
 	m_pParent.PostMessage(WM_COMMAND, ID_ORDERLIST_COPY);
+}
+
+
+void COrderList::OnMergePatterns()
+{
+	m_pParent.PostMessage(WM_COMMAND, ID_ORDERLIST_MERGE);
 }
 
 

--- a/mptrack/Ctrl_seq.cpp
+++ b/mptrack/Ctrl_seq.cpp
@@ -91,6 +91,7 @@ BEGIN_MESSAGE_MAP(COrderList, CWnd)
 	ON_COMMAND(ID_ORDERLIST_NEW,				&COrderList::OnCreateNewPattern)
 	ON_COMMAND(ID_ORDERLIST_COPY,				&COrderList::OnDuplicatePattern)
     ON_COMMAND(ID_ORDERLIST_MERGE,				&COrderList::OnMergePatterns)
+	ON_COMMAND(ID_ORDERLIST_SPLIT,				&COrderList::OnSplitPattern)
 	ON_COMMAND(ID_PATTERNCOPY,					&COrderList::OnPatternCopy)
 	ON_COMMAND(ID_PATTERNPASTE,					&COrderList::OnPatternPaste)
 	ON_COMMAND(ID_SETRESTARTPOS,				&COrderList::OnSetRestartPos)
@@ -560,6 +561,8 @@ LRESULT COrderList::OnCustomKeyMsg(WPARAM wParam, LPARAM)
 		OnDuplicatePattern(); return wParam;
 	case kcMergePattern:
 		OnMergePatterns(); return wParam;
+	case kcSplitPattern:
+		OnSplitPattern(); return wParam;
 	case kcNewPattern:
 		OnCreateNewPattern(); return wParam;
 	}
@@ -1061,6 +1064,8 @@ void COrderList::OnRButtonDown(UINT nFlags, CPoint pt)
 		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_COPY, ih->GetKeyTextFromCommand(kcDuplicatePattern, _T("&Duplicate Pattern")));
 		AppendMenu(hMenu, MF_STRING | greyed, ID_PATTERNCOPY, _T("&Copy Pattern"));
 		AppendMenu(hMenu, MF_STRING, ID_PATTERNPASTE, ih->GetKeyTextFromCommand(kcEditPaste, _T("P&aste Pattern")));
+		AppendMenu(hMenu, MF_SEPARATOR, NULL, _T(""));
+		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_SPLIT, ih->GetKeyTextFromCommand(kcSplitPattern, _T("&Split Pattern")));
 		const bool hasPatternProperties = sndFile.GetModSpecifications().patternRowsMin != sndFile.GetModSpecifications().patternRowsMax;
 		if (hasPatternProperties || sndFile.GetModSpecifications().hasRestartPos)
 		{
@@ -1311,6 +1316,12 @@ void COrderList::OnDuplicatePattern()
 void COrderList::OnMergePatterns()
 {
 	m_pParent.PostMessage(WM_COMMAND, ID_ORDERLIST_MERGE);
+}
+
+
+void COrderList::OnSplitPattern()
+{
+	m_pParent.PostMessage(WM_COMMAND, ID_ORDERLIST_SPLIT);
 }
 
 

--- a/mptrack/Ctrl_seq.cpp
+++ b/mptrack/Ctrl_seq.cpp
@@ -92,6 +92,7 @@ BEGIN_MESSAGE_MAP(COrderList, CWnd)
 	ON_COMMAND(ID_ORDERLIST_COPY,				&COrderList::OnDuplicatePattern)
     ON_COMMAND(ID_ORDERLIST_MERGE,				&COrderList::OnMergePatterns)
 	ON_COMMAND(ID_ORDERLIST_SPLIT,				&COrderList::OnSplitPattern)
+	ON_COMMAND(ID_ORDERLIST_SHIFT,				&COrderList::OnShiftPatternRows)
 	ON_COMMAND(ID_PATTERNCOPY,					&COrderList::OnPatternCopy)
 	ON_COMMAND(ID_PATTERNPASTE,					&COrderList::OnPatternPaste)
 	ON_COMMAND(ID_SETRESTARTPOS,				&COrderList::OnSetRestartPos)
@@ -563,6 +564,8 @@ LRESULT COrderList::OnCustomKeyMsg(WPARAM wParam, LPARAM)
 		OnMergePatterns(); return wParam;
 	case kcSplitPattern:
 		OnSplitPattern(); return wParam;
+	case kcShiftPatternRows:
+		OnShiftPatternRows(); return wParam;
 	case kcNewPattern:
 		OnCreateNewPattern(); return wParam;
 	}
@@ -1050,6 +1053,7 @@ void COrderList::OnRButtonDown(UINT nFlags, CPoint pt)
 		AppendMenu(hMenu, MF_SEPARATOR, NULL, _T(""));
 		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_COPY, ih->GetKeyTextFromCommand(kcDuplicatePattern, _T("&Duplicate Patterns")));
 		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_MERGE, ih->GetKeyTextFromCommand(kcMergePattern, _T("&Merge Patterns")));
+		AppendMenu(hMenu, MF_STRING | greyed, ID_ORDERLIST_SHIFT, ih->GetKeyTextFromCommand(kcShiftPatternRows, _T("&Shift Rows")));
 	} else
 	{
 		// Only one pattern is selected
@@ -1322,6 +1326,12 @@ void COrderList::OnMergePatterns()
 void COrderList::OnSplitPattern()
 {
 	m_pParent.PostMessage(WM_COMMAND, ID_ORDERLIST_SPLIT);
+}
+
+
+void COrderList::OnShiftPatternRows()
+{
+	m_pParent.PostMessage(WM_COMMAND, ID_ORDERLIST_SHIFT);
 }
 
 

--- a/mptrack/mptrack.rc
+++ b/mptrack/mptrack.rc
@@ -2870,12 +2870,6 @@ BEGIN
     IDC_SAMPLE_RESAMPLE     "Resample the entire sample or current selection\nResample"
     IDC_SAMPLE_REVERSE      "Reverse selection\nReverse"
     IDC_COMBO_ZOOM          "Changes the current zoom value\nZoom"
-    IDC_SAMPLE_PLAY         "Play a middle C using the current sample\nPlay sample"
-END
-
-STRINGTABLE
-BEGIN
-    IDC_SAMPLE_DOWNSAMPLE   "Shrink selection\nDownsample"
 END
 
 STRINGTABLE
@@ -2885,7 +2879,13 @@ BEGIN
                             "Play the current pattern from the beginning\nReplay Pattern"
     IDC_PATTERN_STOP        "Stop playing\nStop"
     IDC_PATTERN_RECORD      "Enables the recording of notes\nRecord"
+    IDC_SAMPLE_PLAY         "Play a middle C using the current sample\nPlay sample"
     IDC_PATTERN_NEW         "Create a new pattern\nInsert Pattern"
+END
+
+STRINGTABLE
+BEGIN
+    IDC_SAMPLE_DOWNSAMPLE   "Shrink selection\nDownsample"
 END
 
 STRINGTABLE
@@ -3310,6 +3310,38 @@ END
 
 /////////////////////////////////////////////////////////////////////////////
 //
+// Menu
+//
+
+IDR_VSTMENU MENU
+BEGIN
+    POPUP "&File"
+    BEGIN
+        MENUITEM "&Copy Preset",                ID_EDIT_COPY
+        MENUITEM "&Paste Preset",               ID_EDIT_PASTE
+        MENUITEM SEPARATOR
+        MENUITEM "&Load Preset / Bank...",      ID_PRESET_LOAD
+        MENUITEM "&Save Preset / Bank...",      ID_PRESET_SAVE
+        MENUITEM SEPARATOR
+        MENUITEM "Create &instrument from plugin", ID_PLUGINTOINSTRUMENT
+        MENUITEM "&Randomize Parameters",       ID_PRESET_RANDOM
+    END
+    POPUP "&Info"
+    BEGIN
+        MENUITEM "I&nputs",                     ID_INFO_INPUTS
+        MENUITEM "Ou&tputs",                    ID_INFO_OUPUTS
+        MENUITEM "&Macros",                     ID_INFO_MACROS
+    END
+    POPUP "&Options"
+    BEGIN
+        MENUITEM "&Bypass Plugin",              ID_PLUG_BYPASS
+        MENUITEM "Record &Parameter Changes",   ID_PLUG_RECORDAUTOMATION
+    END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
 // Dialog Info
 //
 
@@ -3350,38 +3382,6 @@ BEGIN
     IDC_COMBO_CHANNEL, 0x403, 3, 0
 0x3631, "\000" 
     0
-END
-
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// Menu
-//
-
-IDR_VSTMENU MENU
-BEGIN
-    POPUP "&File"
-    BEGIN
-        MENUITEM "&Copy Preset",                ID_EDIT_COPY
-        MENUITEM "&Paste Preset",               ID_EDIT_PASTE
-        MENUITEM SEPARATOR
-        MENUITEM "&Load Preset / Bank...",      ID_PRESET_LOAD
-        MENUITEM "&Save Preset / Bank...",      ID_PRESET_SAVE
-        MENUITEM SEPARATOR
-        MENUITEM "Create &instrument from plugin", ID_PLUGINTOINSTRUMENT
-        MENUITEM "&Randomize Parameters",       ID_PRESET_RANDOM
-    END
-    POPUP "&Info"
-    BEGIN
-        MENUITEM "I&nputs",                     ID_INFO_INPUTS
-        MENUITEM "Ou&tputs",                    ID_INFO_OUPUTS
-        MENUITEM "&Macros",                     ID_INFO_MACROS
-    END
-    POPUP "&Options"
-    BEGIN
-        MENUITEM "&Bypass Plugin",              ID_PLUG_BYPASS
-        MENUITEM "Record &Parameter Changes",   ID_PLUG_RECORDAUTOMATION
-    END
 END
 
 

--- a/mptrack/resource.h
+++ b/mptrack/resource.h
@@ -125,6 +125,7 @@
 #define IDD_TEMPO_SWING                 540
 #define IDD_OPTIONS_WINE                541
 #define ID_ORDERLIST_MERGE              901
+#define ID_ORDERLIST_SPLIT              902
 #define IDC_BUTTON1                     1001
 #define IDC_BUTTON2                     1002
 #define IDC_BUTTON3                     1003
@@ -1261,6 +1262,6 @@
 #define _APS_NEXT_RESOURCE_VALUE        544
 #define _APS_NEXT_COMMAND_VALUE         44646
 #define _APS_NEXT_CONTROL_VALUE         2512
-#define _APS_NEXT_SYMED_VALUE           902
+#define _APS_NEXT_SYMED_VALUE           903
 #endif
 #endif

--- a/mptrack/resource.h
+++ b/mptrack/resource.h
@@ -124,6 +124,7 @@
 #define IDD_WECLOME                     539
 #define IDD_TEMPO_SWING                 540
 #define IDD_OPTIONS_WINE                541
+#define ID_ORDERLIST_MERGE              901
 #define IDC_BUTTON1                     1001
 #define IDC_BUTTON2                     1002
 #define IDC_BUTTON3                     1003
@@ -1110,11 +1111,8 @@
 #define ID_INFO                         32920
 #define ID_VIEWPLUGNAMES                32921
 #define ID_EQSLIDER_BASE                32922
-// From here: Command range [ID_EQSLIDER_BASE, ID_EQSLIDER_BASE + MAX_EQ_BANDS]
 #define ID_EQMENU_BASE                  32950
-// From here: Command range [ID_EQMENU_BASE, ID_EQMENU_BASE + EQ_MAX_FREQS]
 #define ID_SELECT_MIDI_DEVICE           33000
-// From here: Command range [ID_SELECT_MIDI_DEVICE, ID_SELECT_MIDI_DEVICE + MAX_MIDI_DEVICES]
 #define ID_EDIT_SPLITRECSELECT          33900
 #define ID_REARRANGE_SAMPLES            33901
 #define ID_CHANNEL_MANAGER              33905
@@ -1128,9 +1126,7 @@
 #define ID_MODTREE_SAVEITEM             33917
 #define ID_PLUGIN_SETUP                 33918
 #define ID_PRESET_SET                   33920
-// From here: Command range [ID_PRESET_SET, ID_PRESET_SET + PRESETS_PER_GROUP]
 #define ID_PLUGSELECT                   35000
-// From here: Command range [ID_PLUGSELECT, ID_PLUGSELECT + MAX_MIXPLUGINS]
 #define ID_VSTMACRO_INFO                36002
 #define ID_VSTINPUT_INFO                36003
 #define ID_APPROX_BPM                   36007
@@ -1160,26 +1156,20 @@
 #define ID_ADDTUNINGGROUPGEOMETRIC      36035
 #define ID_ADDTUNINGGEOMETRIC           36036
 #define ID_SELECTINST                   36100
-// From here: Command range [ID_SELECTINST, ID_SELECTINST + MAX_INSTRUMENTS]
 #define ID_PLUG_RECORDAUTOMATION        37003
 #define ID_LEARN_MACRO_FROM_PLUGGUI     37004
 #define ID_CHANGE_INSTRUMENT            37020
-// From here: Command range [ID_CHANGE_INSTRUMENT, ID_CHANGE_INSTRUMENT + MAX_INSTRUMENTS]
 #define ID_CLEAR_SELECTION              38000
 #define ID_PLUG_PASSKEYS                38001
 #define ID_VIEW_SONGPROPERTIES          38002
 #define ID_SEQUENCE_ITEM                38003
-// From here: Command range [ID_SEQUENCE_ITEM, ID_SEQUENCE_ITEM + MAX_SEQUENCES + 2]
 #define ID_NOTEMAP_EDITSAMPLE           39000
-// From here: Command range [ID_NOTEMAP_EDITSAMPLE, ID_NOTEMAP_EDITSAMPLE + MAX_SAMPLES]
 #define ID_GROW_SELECTION               43001
 #define ID_SHRINK_SELECTION             43002
 #define ID_RUN_SCRIPT                   43003
 #define ID_EXAMPLE_MODULES              43004
-// From here: Command range [ID_EXAMPLE_MODULES, ID_EXAMPLE_MODULES_LASTINRANGE]
 #define ID_EXAMPLE_MODULES_LASTINRANGE  43054
 #define ID_FILE_OPENTEMPLATE            43055
-// From here: Command range [ID_FILE_OPENTEMPLATE, ID_FILE_OPENTEMPLATE_LASTINRANGE]
 #define ID_FILE_OPENTEMPLATE_LASTINRANGE 43105
 #define ID_INDICATOR_TIME               43143
 #define ID_INDICATOR_USER               43144
@@ -1220,11 +1210,9 @@
 #define ID_ORDERLIST_EDIT_COPY_ORDERS   43237
 #define ID_FILE_SAVE_COPY               43238
 #define ID_CHANGE_PCNOTE_PARAM          43242
-// From here: Command range [ID_CHANGE_PCNOTE_PARAM, ID_CHANGE_PCNOTE_PARAM + ModCommand::maxColumnValue]
 #define ID_MODTREE_CLOSE                44243
 #define ID_SAMPLE_GENERATOR_MENU        44244
 #define ID_SAMPLE_GENERATOR_PRESET_MENU 44344
-// From here: Command range [ID_SAMPLE_GENERATOR_PRESET_MENU, ID_SAMPLE_GENERATOR_PRESET_MENU + MAX_SAMPLEGEN_EXPRESSIONS - 1]
 #define ID_SAMPLE_GENERATE              44445
 #define ID_NOTEMAP_TRANS_UP             44446
 #define ID_NOTEMAP_TRANS_DOWN           44447
@@ -1242,15 +1230,12 @@
 #define ID_HELP_EXAMPLEMODULES          44459
 #define ID_FILE_SAVEASTEMPLATE          44460
 #define ID_SAMPLE_CUE_1                 44461
-// From here: Command range [ID_SAMPLE_CUE_1, ID_SAMPLE_CUE_9]
 #define ID_SAMPLE_CUE_9                 44469
 #define ID_ORDERLIST_INSERT_SEPARATOR   44470
 #define ID_ENVELOPE_LOAD                44471
 #define ID_ENVELOPE_SAVE                44472
 #define ID_PLUGINEDITOR_SLIDERS_BASE    44500
-// From here: Command range [ID_PLUGINEDITOR_SLIDERS_BASE, ID_PLUGINEDITOR_SLIDERS_BASE + NUM_PLUGINEDITOR_PARAMETERS]
 #define ID_PLUGINEDITOR_EDIT_BASE       44550
-// From here: Command range [ID_PLUGINEDITOR_EDIT_BASE, ID_PLUGINEDITOR_EDIT_BASE + NUM_PLUGINEDITOR_PARAMETERS]
 #define ID_HELP_SHOWSETTINGSFOLDER      44600
 #define ID_FILE_CLOSEALL                44601
 #define ID_HELPSHOW                     44602
@@ -1263,7 +1248,6 @@
 #define ID_SETQUANTIZE                  44609
 #define ID_PLUG_RECORD_MIDIOUT          44610
 #define ID_MRU_LIST_FIRST               44611
-// From here: Command range [ID_MRU_LIST_FIRST, ID_MRU_LIST_LAST]
 #define ID_MRU_LIST_LAST                44642
 #define ID_FILE_APPENDMODULE            44643
 #define ID_SAMPLE_16BITCONVERT          44644
@@ -1274,9 +1258,9 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_3D_CONTROLS                     1
-#define _APS_NEXT_RESOURCE_VALUE        542
+#define _APS_NEXT_RESOURCE_VALUE        544
 #define _APS_NEXT_COMMAND_VALUE         44646
 #define _APS_NEXT_CONTROL_VALUE         2512
-#define _APS_NEXT_SYMED_VALUE           901
+#define _APS_NEXT_SYMED_VALUE           902
 #endif
 #endif

--- a/mptrack/resource.h
+++ b/mptrack/resource.h
@@ -126,6 +126,7 @@
 #define IDD_OPTIONS_WINE                541
 #define ID_ORDERLIST_MERGE              901
 #define ID_ORDERLIST_SPLIT              902
+#define ID_ORDERLIST_SHIFT              903
 #define IDC_BUTTON1                     1001
 #define IDC_BUTTON2                     1002
 #define IDC_BUTTON3                     1003
@@ -1262,6 +1263,6 @@
 #define _APS_NEXT_RESOURCE_VALUE        544
 #define _APS_NEXT_COMMAND_VALUE         44646
 #define _APS_NEXT_CONTROL_VALUE         2512
-#define _APS_NEXT_SYMED_VALUE           903
+#define _APS_NEXT_SYMED_VALUE           904
 #endif
 #endif


### PR DESCRIPTION
This pull request add three features I found missing and decided to implement within OpenMPT. Those three features can be useful when converting MIDI with nonstandard time signatures, since OpenMPT does not preserve the time structure.

## Merge

This operation will merge a selection of patterns in the order list. This merge is conservative (a new pattern is created)
![openmpt-merge](https://user-images.githubusercontent.com/13079799/61843505-5067de80-ae72-11e9-9a07-4cbca1851a10.gif)

## Split

This operation splits a single pattern into two. All occurences of this pattern will be augmented with occurences of the new patterns.
![openmpt-split](https://user-images.githubusercontent.com/13079799/61843535-6bd2e980-ae72-11e9-9606-633f4858802f.gif)

## Shift rows

This operation is a bit more complex. It moves rows from patterns so, while the song is not changed, the pattern "boundaries" are effectively moved.

The effect of a "positive" shift is that rows from a pattern are moved to the pattern immediately behind:
![openmpt-shift1](https://user-images.githubusercontent.com/13079799/61843576-a2a8ff80-ae72-11e9-8b52-7bd1be7a80cd.gif)

The effect of a "negative" shift is that rows from a pattern are moved to the pattern immediately ahead:
![openmpt-shift2](https://user-images.githubusercontent.com/13079799/61843582-ae94c180-ae72-11e9-9770-ed409d2f2814.gif)

(PS: I am aware that pull requests are not the right way to contribute to OpenMPT, but I do not know exactly how I would do it in Subversion. I am sorry)