### PR TITLE
Haiku support

### DIFF
--- a/common/CompilerDetect.h
+++ b/common/CompilerDetect.h
@@ -242,6 +242,8 @@
 	#define MPT_OS_NETBSD 1
 #elif defined(__unix__)
 	#define MPT_OS_GENERIC_UNIX 1
+#elif defined(__HAIKU__)
+	#define MPT_OS_HAIKU 1
 #else
 	#define MPT_OS_UNKNOWN 1
 #endif
@@ -281,6 +283,9 @@
 #endif
 #ifndef MPT_OS_GENERIC_UNIX
 #define MPT_OS_GENERIC_UNIX 0
+#endif
+#ifndef MPT_OS_HAIKU
+#define MPT_OS_HAIKU 0
 #endif
 #ifndef MPT_OS_UNKNOWN
 #define MPT_OS_UNKNOWN 0

--- a/common/CompilerDetect.h
+++ b/common/CompilerDetect.h
@@ -309,7 +309,7 @@
 
 
 #if MPT_CXX_AT_LEAST(17)
-#if MPT_COMPILER_MSVC || MPT_GCC_BEFORE(8,1,0) || MPT_CLANG_BEFORE(5,0,0) || (MPT_COMPILER_GCC && defined(__GLIBCXX__) && (defined(__MINGW32__) || defined(__MINGW64__))) || (MPT_COMPILER_CLANG && defined(__GLIBCXX__)) || (MPT_COMPILER_CLANG && MPT_OS_MACOSX_OR_IOS) || MPT_OS_OPENBSD || MPT_OS_EMSCRIPTEN || (defined(__clang__) && defined(_MSC_VER))
+#if MPT_COMPILER_MSVC || MPT_GCC_BEFORE(8,1,0) || MPT_CLANG_BEFORE(5,0,0) || (MPT_COMPILER_GCC && defined(__GLIBCXX__) && (defined(__MINGW32__) || defined(__MINGW64__))) || (MPT_COMPILER_CLANG && defined(__GLIBCXX__)) || (MPT_COMPILER_CLANG && MPT_OS_MACOSX_OR_IOS) || MPT_OS_OPENBSD || MPT_OS_EMSCRIPTEN || MPT_OS_HAIKU || (defined(__clang__) && defined(_MSC_VER))
 #define MPT_COMPILER_QUIRK_NO_ALIGNEDALLOC
 #endif
 #endif


### PR DESCRIPTION
Haiku uses libopenmpt trough ffmpeg for module music playback.
With this patch libopenmpt builds fine. Test passes.