### PR TITLE
Include <ostream> in mptUUID.h

### DIFF
--- a/common/mptUUID.h
+++ b/common/mptUUID.h
@@ -14,6 +14,7 @@
 
 
 #include "Endianness.h"
+#include <ostream>
 
 #if MPT_OS_WINDOWS
 #if defined(MODPLUG_TRACKER) || defined(MPT_WITH_DMO)


### PR DESCRIPTION
In a future version of MSVC, \<string> doesn't transitively include\<ostream>.
This port will compile failed with mptUUID.h(128): error C2039: 'domain_error': is not a member of 'std', so I add include\<ostream> into the header file.