### PR TITLE
openmpt123: fix build on gcc-12

### DIFF
--- a/openmpt123/openmpt123.cpp
+++ b/openmpt123/openmpt123.cpp
@@ -46,6 +46,7 @@ static const char * const license =
 #include <limits>
 #include <locale>
 #include <map>
+#include <memory>
 #include <random>
 #include <set>
 #include <sstream>


### PR DESCRIPTION
`gcc-12` cleaned up implicit header includes and now requires
explicit '<memory>' for 'std::unique_ptr<>':

    openmpt123/openmpt123.cpp:194:14: error: 'unique_ptr' in namespace 'std' does not name a template type
      194 |         std::unique_ptr<file_audio_stream_base> impl;
          |              ^~~~~~~~~~
    openmpt123/openmpt123.cpp:109:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
      108 | #include "openmpt123_waveout.hpp"
      +++ |+#include <memory>
      109 |