### PR TITLE
Fixed typo in Modedit.cpp

### DIFF
--- a/mptrack/Modedit.cpp
+++ b/mptrack/Modedit.cpp
@@ -486,7 +486,7 @@ INSTRUMENTINDEX CModDoc::ReArrangeInstruments(const std::vector<INSTRUMENTINDEX>
 		m_SndFile.DestroyInstrument(i, doNoDeleteAssociatedSamples);
 	}
 
-	PrepareUndoForAllPatterns(false, "Rearrange Instrumens");
+	PrepareUndoForAllPatterns(false, "Rearrange Instruments");
 	GetInstrumentUndo().RearrangeInstruments(newIndex);
 	m_SndFile.Patterns.ForEachModCommand([&newIndex] (ModCommand &m)
 	{


### PR DESCRIPTION
"Instrumens" → "Instruments"