### PR TITLE
Fix note range in UltraTracker modules

### DIFF
--- a/soundlib/Load_ult.cpp
+++ b/soundlib/Load_ult.cpp
@@ -63,7 +63,7 @@ struct UltSample
 		mptSmp.nSustainEnd = std::min(static_cast<SmpLength>(loopEnd), mptSmp.nLength);
 		mptSmp.nVolume = volume;
 
-		mptSmp.nC5Speed = speed;
+		mptSmp.nC5Speed = speed * 2; // doubled to fit the note range
 		if(finetune)
 		{
 			mptSmp.Transpose(finetune / (12.0 * 32768.0));
@@ -207,7 +207,7 @@ static int ReadULTEvent(ModCommand &m, FileReader &file, uint8 version)
 		b = file.ReadUint8();
 	}
 
-	m.note = (b > 0 && b < 61) ? (b + 35 + NOTE_MIN) : NOTE_NONE;
+	m.note = (b > 0 && b < 97) ? (b + 23 + NOTE_MIN) : NOTE_NONE;
 
 	const auto [instr, cmd, para1, para2] = file.ReadArray<uint8, 4>();
 	


### PR DESCRIPTION
I extended the upper limit of the note range from 60 to 96, because UltraTracker actually allows notes up to B-7, not B-4.

This would cause octave 7 to be converted to octave 10 (which is invalid). To prevent this, the octaves are now shifted by 2 instead of 3, and sample rates are doubled to compensate for this change.