### PR TITLE
Fix channel plugins not loading properly in IT

### DIFF
--- a/soundlib/Load_it.cpp
+++ b/soundlib/Load_it.cpp
@@ -2134,6 +2134,10 @@ std::pair<bool, bool> CSoundFile::LoadMixPlugins(FileReader &file)
 		// Channel FX
 		if(!memcmp(code, "CHFX", 4))
 		{
+			if(GetNumChannels() == 0)
+			{
+				ChnSettings.resize(std::min(MAX_BASECHANNELS, static_cast<CHANNELINDEX>(chunkSize / 4)));
+			}
 			for(auto &chn : ChnSettings)
 			{
 				chn.nMixPlugin = static_cast<PLUGINDEX>(chunk.ReadUint32LE());


### PR DESCRIPTION
`LoadMixPlugins` was not updated properly to match the changes in r20950, causing IT/MPTM files to load without channel plugins, unless the channels also have names. This patch fixes the issue.