### PR TITLE
Add proper STM tracker detection

### DIFF
--- a/soundlib/Load_stm.cpp
+++ b/soundlib/Load_stm.cpp
@@ -235,8 +235,23 @@ bool CSoundFile::ReadSTM(FileReader &file, ModLoadingFlags loadFlags)
 
 	m_modFormat.formatName = UL_("Scream Tracker 2");
 	m_modFormat.type = UL_("stm");
-	m_modFormat.madeWithTracker = MPT_UFORMAT("Scream Tracker {}.{}")(fileHeader.verMajor, mpt::ufmt::dec0<2>(fileHeader.verMinor));
 	m_modFormat.charset = mpt::Charset::CP437;
+
+	if(!std::memcmp(fileHeader.trackerName, "!Scream!", 8))
+	{
+		if(fileHeader.verMinor >= 21)
+			m_modFormat.madeWithTracker = UL_("Scream Tracker 2.2 - 2.4 or compatible");
+		else
+			m_modFormat.madeWithTracker = MPT_UFORMAT("Scream Tracker {}.{} or compatible")(fileHeader.verMajor, mpt::ufmt::dec0<2>(fileHeader.verMinor));
+	}
+	else if(!std::memcmp(fileHeader.trackerName, "BMOD2STM", 8))
+		m_modFormat.madeWithTracker = UL_("BMOD2STM");
+	else if(!std::memcmp(fileHeader.trackerName, "WUZAMOD!", 8))
+		m_modFormat.madeWithTracker = UL_("Wuzamod");
+	else if(!std::memcmp(fileHeader.trackerName, "SWavePro", 8))
+		m_modFormat.madeWithTracker = UL_("SoundWave Pro");
+	else
+		m_modFormat.madeWithTracker = UL_("Unknown");
 
 	m_playBehaviour.set(kST3SampleSwap);
 


### PR DESCRIPTION
I fixed a few things in the STM tracker detection:
* All ST2 versions from 2.2 to 2.4 write the version number as 2.21, so I changed the text to `Scream Tracker 2.2 - 2.4` if the minor version is at least 21.
* Added separate tracker names for `BMODSTM`, `WUZAMOD!`, and `SWavePro` in the "tracker name" field. Other values are treated as "Unknown".

I'm not very familiar with C++, so feel free to let me know if I messed up or could have done something better.