### PR TITLE
Add ST3.21 version detection

### DIFF
--- a/soundlib/Load_s3m.cpp
+++ b/soundlib/Load_s3m.cpp
@@ -283,9 +283,17 @@ bool CSoundFile::ReadS3M(FileReader &file, ModLoadingFlags loadFlags)
 			// though several ST3.01/3.03 files with ultra-click values of 16 have been found as well.
 			// However, we won't fingerprint these values here as it's unlikely that there is any other tracker out there disguising as ST3 and using a strange ultra-click value.
 			// Also, re-saving a file with a strange ultra-click value in ST3 doesn't fix this value unless the user manually changes it, or if it's below 16.
-			madeWithTracker = UL_("Scream Tracker");
-			formatTrackerStr = true;
 			isST3 = true;
+			if(fileHeader.cwtv == S3MFileHeader::trkST3_20)
+			{
+				// 3.21 writes the version number as 3.20. There is no known way to differentiate between the two.
+				madeWithTracker = UL_("Scream Tracker 3.20 - 3.21");
+			}
+			else
+			{
+				madeWithTracker = UL_("Scream Tracker");
+				formatTrackerStr = true;
+			}
 		}
 		break;
 	case S3MFileHeader::trkImagoOrpheus:


### PR DESCRIPTION
S3M files with a cwtv of $1320 are now detected as "Scream Tracker 3.20 - 3.21", since 3.21 writes the same cwtv as 3.20.