### PR TITLE
Fix typo in ST2 version

### DIFF
--- a/soundlib/Load_stm.cpp
+++ b/soundlib/Load_stm.cpp
@@ -240,7 +240,7 @@ bool CSoundFile::ReadSTM(FileReader &file, ModLoadingFlags loadFlags)
 	if(!std::memcmp(fileHeader.trackerName, "!Scream!", 8))
 	{
 		if(fileHeader.verMinor >= 21)
-			m_modFormat.madeWithTracker = UL_("Scream Tracker 2.2 - 2.4 or compatible");
+			m_modFormat.madeWithTracker = UL_("Scream Tracker 2.2 - 2.3 or compatible");
 		else
 			m_modFormat.madeWithTracker = MPT_UFORMAT("Scream Tracker {}.{} or compatible")(fileHeader.verMajor, mpt::ufmt::dec0<2>(fileHeader.verMinor));
 	}


### PR DESCRIPTION
This fixes a mistake in my previous patch to STM version detection (2.4 -> 2.3). (sorry about that!)