### PR TITLE
More accurate Impulse Tracker version detection

### DIFF
--- a/soundlib/Load_it.cpp
+++ b/soundlib/Load_it.cpp
@@ -1234,15 +1234,18 @@ bool CSoundFile::ReadIT(FileReader &file, ModLoadingFlags loadFlags)
 				if(fileHeader.cmwt > 0x0214)
 				{
 					madeWithTracker = UL_("Impulse Tracker 2.15");
-				} else if(fileHeader.cwtv > 0x0214)
-				{
-					// Patched update of IT 2.14 (0x0215 - 0x0217 == p1 - p3)
-					// p4 (as found on modland) adds the ITVSOUND driver, but doesn't seem to change
-					// anything as far as file saving is concerned.
-					madeWithTracker = MPT_UFORMAT("Impulse Tracker 2.14p{}")(fileHeader.cwtv - 0x0214);
-				} else
+				} else if(fileHeader.cwtv <= 0x0214)
 				{
 					madeWithTracker = MPT_UFORMAT("Impulse Tracker {}.{}")((fileHeader.cwtv & 0x0F00) >> 8, mpt::ufmt::hex0<2>((fileHeader.cwtv & 0xFF)));
+				} else
+				{
+					switch(fileHeader.cwtv)
+					{
+					case 0x0215: madeWithTracker = UL_("Impulse Tracker 2.14p1 / 2.15");   break;
+					case 0x0216: madeWithTracker = UL_("Impulse Tracker 2.14p2/3 / 2.15"); break;  // Includes the 2.15 build on Modland
+					case 0x0217: madeWithTracker = UL_("Impulse Tracker 2.14p4/5 / 2.15"); break;  // Includes current GitHub version
+					default:     madeWithTracker = UL_("Impulse Tracker 2.15");
+					}
 				}
 				if(m_FileHistory.empty() && fileHeader.reserved != 0)
 				{

--- a/soundlib/Load_s3m.cpp
+++ b/soundlib/Load_s3m.cpp
@@ -308,12 +308,16 @@ bool CSoundFile::ReadS3M(FileReader &file, ModLoadingFlags loadFlags)
 		{
 			madeWithTracker = UL_("Impulse Tracker");
 			formatTrackerStr = true;
-		} else if(fileHeader.cwtv == S3MFileHeader::trkIT1_old)
-		{
-			madeWithTracker = UL_("Impulse Tracker 1.03");  // Could also be 1.02, maybe? I don't have that one
 		} else
 		{
-			madeWithTracker = MPT_UFORMAT("Impulse Tracker 2.14p{}")(fileHeader.cwtv - S3MFileHeader::trkIT2_14);
+			switch(fileHeader.cwtv)
+			{
+				case S3MFileHeader::trkIT1_old:    madeWithTracker = UL_("Impulse Tracker 1.03");            break;  // Could also be 1.02, maybe? I don't have that one
+				case S3MFileHeader::trkIT2_14 + 1: madeWithTracker = UL_("Impulse Tracker 2.14p1 / 2.15");   break;
+				case S3MFileHeader::trkIT2_14 + 2: madeWithTracker = UL_("Impulse Tracker 2.14p2/3 / 2.15"); break;  // Includes the 2.15 build on Modland
+				case S3MFileHeader::trkIT2_14 + 3: madeWithTracker = UL_("Impulse Tracker 2.14p4/5 / 2.15"); break;  // Includes current GitHub version
+				default:                           madeWithTracker = UL_("Impulse Tracker 2.15");
+			}
 		}
 		if(fileHeader.cwtv >= S3MFileHeader::trkIT2_07 && fileHeader.reserved3 != 0)
 		{


### PR DESCRIPTION
I changed the 2.14 patch detection to be correct, according to the 2.14 patches available on Modland:
* 2.14p3: $0216
* 2.14p4: $0217
* 2.14p5: $0217
I assume 2.14p1 uses $0215 and 2.14p2 uses $0216, and OpenMPT was detecting those correctly prior to this PR.
If any of this is wrong, let me know.

I also made it clarify that files with cwtv > $0214 and cmwt <= $0214 could have been made with 2.15. (i.e. made with 2.15 but saved in 214/2xx mode)