### PR TITLE
Change minimum pattern length to 32 for IT files

### DIFF
--- a/soundlib/mod_specifications.cpp
+++ b/soundlib/mod_specifications.cpp
@@ -323,7 +323,7 @@ constexpr CModSpecifications it_ =
 	255,										// Max tempo
 	1,											// Min Speed
 	255,										// Max Speed
-	1,											// Min pattern rows
+	32,											// Min pattern rows
 	200,										// Max pattern rows
 	25,											// Max mod name length
 	25,											// Max sample name length


### PR DESCRIPTION
This issue was already submitted as a bug report ([1716](https://bugs.openmpt.org/view.php?id=1716)), but was rejected.

Impulse Tracker *does* seem to have trouble reading short patterns. The results seem to vary from machine to machine.
Sometimes there are no issues, and sometimes there are corruptions and/or crashes.

Here are some examples:

* [glassvol.it.gz](https://github.com/user-attachments/files/17453056/glassvol.it.gz)
  * 86Box (ASUS P2B-LS): glitches at pattern position 2 (right after the 1-row pattern), and locks up at pattern position 3 ([video attached](https://github.com/user-attachments/assets/b26e8bb7-9cee-4090-9d32-d3086c47fef5)).
  * DOSBox: freezes (and sometimes closes) on pattern position 2.

* [b1.it.gz](https://github.com/user-attachments/files/17453139/b1.it.gz)
  * DOSBox-X: freezes on pattern position 1 (right after an 8-row pattern) ([video attached](https://github.com/user-attachments/assets/4a671a09-ffa4-4a77-962c-fb3a8d7f929c)).
  * 86Box: seems to work fine

The tests were performed on the latest GitHub commit of Impulse Tracker.

