### PR TITLE
Show default volume for noteless instruments in sample mode

### DIFF
--- a/mptrack/Draw_pat.cpp
+++ b/mptrack/Draw_pat.cpp
@@ -986,13 +986,13 @@ void CViewPattern::DrawPatternData(HDC hdc, PATTERNINDEX nPattern, bool selEnabl
 			const ModCommand *m = pattern.GetpModCommand(row, static_cast<CHANNELINDEX>(col));
 
 			// Should empty volume commands be replaced with a volume command showing the default volume?
-			const bool drawDefaultVolume = DrawDefaultVolume(m);
+			const bool drawDefaultVolume = DrawDefaultVolume(m, sndFile);
 
 			DWORD dwSpeedUpMask = 0;
 			if(useSpeedUpMask && (m_chnState[col].selectedCols & COLUMN_BITS_SKIP) && (row))
 			{
 				const ModCommand *mold = m - ncols;
-				const bool drawOldDefaultVolume = DrawDefaultVolume(mold);
+				const bool drawOldDefaultVolume = DrawDefaultVolume(mold, sndFile);
 
 				if(m->note == mold->note || !m_visibleColumns[PatternCursor::noteColumn])
 					dwSpeedUpMask |= COLUMN_BITS_NOTE;

--- a/mptrack/View_pat.h
+++ b/mptrack/View_pat.h
@@ -301,7 +301,16 @@ public:
 	void DrawDragSel(HDC hdc);
 	void OnDrawDragSel();
 	// True if default volume should be drawn for a given cell.
-	static bool DrawDefaultVolume(const ModCommand *m) { return (TrackerSettings::Instance().m_dwPatternSetup & PATTERN_SHOWDEFAULTVOLUME) && m->volcmd == VOLCMD_NONE && m->command != CMD_VOLUME && m->command != CMD_VOLUME8 && m->instr != 0 && m->IsNote(); }
+	static bool DrawDefaultVolume(const ModCommand *m, const CSoundFile &sndFile)
+	{
+		return
+			(TrackerSettings::Instance().m_dwPatternSetup & PATTERN_SHOWDEFAULTVOLUME) &&
+			m->volcmd == VOLCMD_NONE &&
+			m->command != CMD_VOLUME &&
+			m->command != CMD_VOLUME8 &&
+			m->instr != 0 &&
+			(m->IsNote() || (m->IsNoteOrEmpty() && sndFile.m_nInstruments == 0));
+	}
 
 	void CursorJump(int distance, bool snap);
 


### PR DESCRIPTION
I thought this would be a nice feature to have.
(If this feels out of place, maybe you could implement this as a hidden setting).