### PR TITLE
Changes to autosaving

### DIFF
--- a/mptrack/CommandSet.cpp
+++ b/mptrack/CommandSet.cpp
@@ -1399,6 +1399,7 @@ static constexpr struct
 	{2104, kcToggleVisibilityVolumeColumn, _T("Toggle volume column visibility")},
 	{2105, kcToggleVisibilityEffectColumn, _T("Toggle effect column visibility")},
 	{2106, kcFileOpenTemplate, _T("File/Open Template")},
+	{2107, kcFileOpenAutoSaves, _T("File/Open Auto Saves")},
 };
 // clang-format on
 

--- a/mptrack/CommandSet.h
+++ b/mptrack/CommandSet.h
@@ -75,6 +75,7 @@ enum CommandID
 	kcStartFile = kcGlobalStart,
 	kcFileNew = kcStartFile,
 	kcFileOpen,
+	kcFileOpenAutoSaves,
 	kcFileAppend,
 	kcFileClose,
 	kcFileCloseAll,

--- a/mptrack/InputHandler.cpp
+++ b/mptrack/InputHandler.cpp
@@ -392,6 +392,7 @@ CString CInputHandler::GetMenuText(UINT id) const
 		{ ID_FILE_OPEN,                     kcFileOpen,          _T("&Open...") },
 		{ ID_FILE_OPENTEMPLATE,             kcNull,              _T("Open &Template") },
 		{ ID_FILE_OPENTEMPLATE_LASTINRANGE, kcFileOpenTemplate,  _T("&Browse...") },
+		{ ID_FILE_OPENAUTOSAVES,            kcFileOpenAutoSaves, _T("Open A&uto Saves...") },
 		{ ID_FILE_CLOSE,                    kcFileClose,         _T("&Close") },
 		{ ID_FILE_CLOSEALL,                 kcFileCloseAll,      _T("C&lose All") },
 		{ ID_FILE_APPENDMODULE,             kcFileAppend,        _T("Appen&d Module...") },
@@ -476,6 +477,7 @@ void CInputHandler::UpdateMainMenu()
 	{
 		ID_FILE_OPEN,
 		ID_FILE_OPENTEMPLATE_LASTINRANGE,
+		ID_FILE_OPENAUTOSAVES,
 		ID_FILE_APPENDMODULE,
 		ID_FILE_CLOSE,
 		ID_FILE_CLOSEALL,

--- a/mptrack/MainFrm.cpp
+++ b/mptrack/MainFrm.cpp
@@ -2561,6 +2561,7 @@ LRESULT CMainFrame::OnCustomKeyMsg(WPARAM wParam, LPARAM lParam)
 		case kcNextOctave: OnNextOctave(); break;
 		case kcFileNew: theApp.OnFileNew(); break;
 		case kcFileOpen: theApp.OnFileOpen(); break;
+		case kcFileOpenAutoSaves: theApp.OnFileOpenAutoSaves(); break;
 		case kcMidiRecord: OnMidiRecord(); break;
 		case kcHelp: OnHelp(); break;
 		case kcViewAddPlugin: OnPluginManager(); break;

--- a/mptrack/Mptrack.cpp
+++ b/mptrack/Mptrack.cpp
@@ -259,6 +259,12 @@ void CTrackApp::OnFileCloseAll()
 }
 
 
+void CTrackApp::OnUpdateAutoSaveFolderSet(CCmdUI *cmd)
+{
+	cmd->Enable(!theApp.GetTrackerSettings().AutosaveUseOriginalPath);
+}
+
+
 void CTrackApp::OnUpdateAnyDocsOpen(CCmdUI *cmd)
 {
 	cmd->Enable(!GetModDocTemplate()->empty());
@@ -632,17 +638,19 @@ MODTYPE CTrackApp::m_nDefaultDocType = MOD_TYPE_IT;
 
 BEGIN_MESSAGE_MAP(CTrackApp, CWinApp)
 	//{{AFX_MSG_MAP(CTrackApp)
-	ON_COMMAND(ID_FILE_NEW,       &CTrackApp::OnFileNew)
-	ON_COMMAND(ID_FILE_NEWMOD,    &CTrackApp::OnFileNewMOD_Amiga)
-	ON_COMMAND(ID_FILE_NEWMOD_PC, &CTrackApp::OnFileNewMOD_PC)
-	ON_COMMAND(ID_FILE_NEWS3M,    &CTrackApp::OnFileNewS3M)
-	ON_COMMAND(ID_FILE_NEWXM,     &CTrackApp::OnFileNewXM)
-	ON_COMMAND(ID_FILE_NEWIT,     &CTrackApp::OnFileNewIT)
-	ON_COMMAND(ID_NEW_MPT,        &CTrackApp::OnFileNewMPT)
-	ON_COMMAND(ID_FILE_OPEN,      &CTrackApp::OnFileOpen)
-	ON_COMMAND(ID_FILE_CLOSEALL,  &CTrackApp::OnFileCloseAll)
-	ON_COMMAND(ID_APP_ABOUT,      &CTrackApp::OnAppAbout)
-	ON_UPDATE_COMMAND_UI(ID_FILE_CLOSEALL, &CTrackApp::OnUpdateAnyDocsOpen)
+	ON_COMMAND(ID_FILE_NEW,           &CTrackApp::OnFileNew)
+	ON_COMMAND(ID_FILE_NEWMOD,        &CTrackApp::OnFileNewMOD_Amiga)
+	ON_COMMAND(ID_FILE_NEWMOD_PC,     &CTrackApp::OnFileNewMOD_PC)
+	ON_COMMAND(ID_FILE_NEWS3M,        &CTrackApp::OnFileNewS3M)
+	ON_COMMAND(ID_FILE_NEWXM,         &CTrackApp::OnFileNewXM)
+	ON_COMMAND(ID_FILE_NEWIT,         &CTrackApp::OnFileNewIT)
+	ON_COMMAND(ID_NEW_MPT,            &CTrackApp::OnFileNewMPT)
+	ON_COMMAND(ID_FILE_OPEN,          &CTrackApp::OnFileOpen)
+	ON_COMMAND(ID_FILE_OPENAUTOSAVES, &CTrackApp::OnFileOpenAutoSaves)
+	ON_COMMAND(ID_FILE_CLOSEALL,      &CTrackApp::OnFileCloseAll)
+	ON_COMMAND(ID_APP_ABOUT,          &CTrackApp::OnAppAbout)
+	ON_UPDATE_COMMAND_UI(ID_FILE_OPENAUTOSAVES, &CTrackApp::OnUpdateAutoSaveFolderSet)
+	ON_UPDATE_COMMAND_UI(ID_FILE_CLOSEALL,      &CTrackApp::OnUpdateAnyDocsOpen)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -1726,14 +1734,26 @@ void CTrackApp::OpenModulesDialog(std::vector<mpt::PathString> &files, const mpt
 }
 
 
-void CTrackApp::OnFileOpen()
+static void OnFileOpen(const mpt::PathString &overridePath = mpt::PathString())
 {
 	FileDialog::PathList files;
-	OpenModulesDialog(files);
+	theApp.OpenModulesDialog(files, overridePath);
 	for(const auto &file : files)
 	{
-		OpenDocumentFile(file.ToCString());
+		theApp.OpenDocumentFile(file.ToCString());
 	}
+}
+
+
+void CTrackApp::OnFileOpen()
+{
+	::OnFileOpen();
+}
+
+
+void CTrackApp::OnFileOpenAutoSaves()
+{
+	::OnFileOpen(theApp.GetTrackerSettings().AutosavePath.GetDefaultDir());
 }
 
 

--- a/mptrack/Mptrack.h
+++ b/mptrack/Mptrack.h
@@ -339,9 +339,12 @@ protected:
 	afx_msg void OnFileNewMPT() { NewDocument(MOD_TYPE_MPT); }
 
 	afx_msg void OnFileOpen();
+	afx_msg void OnFileOpenAutoSaves();
 	afx_msg void OnAppAbout();
 
 	afx_msg void OnFileCloseAll();
+
+	afx_msg void OnUpdateAutoSaveFolderSet(CCmdUI *cmd);
 	afx_msg void OnUpdateAnyDocsOpen(CCmdUI *cmd);
 
 	//}}AFX_MSG

--- a/mptrack/TrackerSettings.cpp
+++ b/mptrack/TrackerSettings.cpp
@@ -315,8 +315,8 @@ TrackerSettings::TrackerSettings(SettingsContainer &conf)
 	, AutosaveEnabled(conf, UL_("AutoSave"), UL_("Enabled"), true)
 	, AutosaveIntervalMinutes(conf, UL_("AutoSave"), UL_("IntervalMinutes"), 10)
 	, AutosaveHistoryDepth(conf, UL_("AutoSave"), UL_("BackupHistory"), 3)
-	, AutosaveUseOriginalPath(conf, UL_("AutoSave"), UL_("UseOriginalPath"), true)
-	, AutosavePath(conf, UL_("AutoSave"), UL_("Path"), mpt::common_directories::get_temp_directory())
+	, AutosaveUseOriginalPath(conf, UL_("AutoSave"), UL_("UseOriginalPath"), false)
+	, AutosavePath(conf, UL_("AutoSave"), UL_("Path"), mpt::common_directories::get_temp_directory() + P_("OpenMPT Auto Saves\\"))
 	// Paths
 	, PathSongs(conf, UL_("Paths"), UL_("Songs_Directory"), mpt::PathString())
 	, PathSamples(conf, UL_("Paths"), UL_("Samples_Directory"), mpt::PathString())
@@ -879,6 +879,7 @@ TrackerSettings::TrackerSettings(SettingsContainer &conf)
 
 	// Paths
 	m_szKbdFile = theApp.PathInstallRelativeToAbsolute(m_szKbdFile);
+	CreateDirectory(AutosavePath.GetDefaultDir().AsNative().c_str(), 0);
 
 	// Sample undo buffer size (used to be a hidden, absolute setting in MiB)
 	int64 oldUndoSize = m_SampleUndoBufferSize.Get().GetSizeInPercent();

--- a/mptrack/mptrack.rc
+++ b/mptrack/mptrack.rc
@@ -2783,7 +2783,8 @@ BEGIN
             MENUITEM "Open&MPT Module",             ID_NEW_MPT
         END
         MENUITEM "&Open...\tCtrl+O",            ID_FILE_OPEN
-        MENUITEM "Open template",               65535
+        MENUITEM "Open Template",               ID_FILE_OPENTEMPLATE
+        MENUITEM "Open Auto Saves...",          ID_FILE_OPENAUTOSAVES
         MENUITEM "Appen&d Module...",           ID_FILE_APPENDMODULE
         MENUITEM "&Close",                      ID_FILE_CLOSE
         MENUITEM "C&lose All",                  ID_FILE_CLOSEALL

--- a/mptrack/resource.h
+++ b/mptrack/resource.h
@@ -1315,6 +1315,7 @@
 #define ID_FILE_SAVEOPL                 44654
 #define ID_CONVERT_NORMAL_TO_SUSTAIN    44655
 #define ID_CONVERT_SUSTAIN_TO_NORMAL    44656
+#define ID_FILE_OPENAUTOSAVES           44657
 
 // Next default values for new objects
 // 
@@ -1322,7 +1323,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_3D_CONTROLS                     1
 #define _APS_NEXT_RESOURCE_VALUE        543
-#define _APS_NEXT_COMMAND_VALUE         44657
+#define _APS_NEXT_COMMAND_VALUE         44658
 #define _APS_NEXT_CONTROL_VALUE         2518
 #define _APS_NEXT_SYMED_VALUE           901
 #endif


### PR DESCRIPTION
I tried to implement the changes suggested in [issue 1837](https://bugs.openmpt.org/view.php?id=1837).

* Autosaving now uses a custom directory by default (`%temp%/OpenMPT Auto Saves`).
* Added a file menu entry for opening the autosave folder.

Let me know if I made any mistakes or could have done something better.
